### PR TITLE
Don't rely solely on Unix conventions when locating Python in a real_…

### DIFF
--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -33,7 +33,7 @@ def tox_testenv_create(venv, action):
     # Bypass hook when venv is not available for the target Python ver
     info = venv.envconfig.config.interpreters.get_info(
         envconfig=venv.envconfig)
-    if info.version_info < (3, 3):
+    if info.version_info is None or info.version_info < (3, 3):
         return
 
     config_interpreter = venv.getsupportedinterpreter()

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import platform
 
 from tox.config import hookimpl
 
@@ -15,7 +16,12 @@ def real_python3(python):
     process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, _ = process.communicate()
     output = output.decode('UTF-8').strip()
-    path = os.path.join(output, 'bin/python3')
+    path_to_python = (
+        r'Scripts\python.exe'
+        if platform.system() == 'Windows' else
+        'bin/python3'
+    )
+    path = os.path.join(output, path_to_python)
 
     valid = process.returncode == 0 and os.path.isfile(path)
     return path if valid else python

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -29,8 +29,11 @@ def real_python3(python):
 
 @hookimpl
 def tox_testenv_create(venv, action):
-    # defautl to tox impl if not python3
-    if not venv._ispython3():
+
+    # Bypass hook when venv is not available for the target Python ver
+    info = venv.envconfig.config.interpreters.get_info(
+        envconfig=venv.envconfig)
+    if info.version_info < (3, 3):
         return
 
     config_interpreter = venv.getsupportedinterpreter()


### PR DESCRIPTION
…prefix, as it won't be found when running on Windows. Ref #1.