### PR TITLE
Prevent test failure due to Travis pyenv misconfiguration

### DIFF
--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -385,11 +385,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.5'):
-        pytest.skip("needs python3.5")
+    if not py.path.local.sysfind('python3'):
+        pytest.skip("needs python3")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.5
+        basepython=python3
         deps=
             dep1
             dep2

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -385,11 +385,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.6'):
-        pytest.skip("needs python3.6")
+    if not py.path.local.sysfind('python3.5'):
+        pytest.skip("needs python3.5")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.6
+        basepython=python3.5
         deps=
             dep1
             dep2


### PR DESCRIPTION
Travis-CI may have misconfigured pyenv, resulting in broken builds. See travis-ci/travis-ci#8363 for more details. 