### PR TITLE
Improve python3 detection, fix windows real path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,9 @@ tox-venv
 
 .. image:: https://travis-ci.org/tox-dev/tox-venv.svg?branch=master
   :target: https://travis-ci.org/tox-dev/tox-venv
+.. image:: https://ci.appveyor.com/api/projects/status/fak35ur9yibmn0ly?svg=true
+  :target: https://ci.appveyor.com/project/rpkilby/tox-venv
+
 
 
 What is tox-venv?

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
 
 test_script:
   - C:\Python36\scripts\tox
-  - C:\Python36\scripts\tox --installpkg ./dist/tox_venv-*.whl
 
 cache:
   - '%LOCALAPPDATA%\pip\cache'

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -21,11 +21,20 @@ def real_python3(python):
     return path if valid else python
 
 
+def use_builtin_venv(venv):
+    """
+    Determine if the builtin venv module should be used to create the testenv's
+    virtual environment. The venv module was added in python 3.3, although some
+    options are not supported until 3.4 and later.
+    """
+    version = venv.envconfig.python_info.version_info
+    return version is not None and version >= (3, 3)
+
+
 @hookimpl
 def tox_testenv_create(venv, action):
     # Bypass hook when venv is not available for the target python version
-    version = venv.envconfig.python_info.version_info
-    if version is not None and version < (3, 3):
+    if not use_builtin_venv(venv):
         return
 
     config_interpreter = venv.getsupportedinterpreter()

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -17,8 +17,13 @@ def real_python3(python):
     output = output.decode('UTF-8').strip()
     path = os.path.join(output, 'bin/python3')
 
-    valid = process.returncode == 0 and os.path.isfile(path)
-    return path if valid else python
+    # process fails, implies *not* in active virtualenv
+    if not process.returncode == 0:
+        return python
+
+    # the executable path must exist
+    assert os.path.isfile(path)
+    return path
 
 
 def use_builtin_venv(venv):

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -6,9 +6,22 @@ from tox.config import hookimpl
 
 def real_python3(python):
     """
-    use real_prefix to determine if we're running inside a virtualenv,
-    and if so, use it as the base path to determine the real python
-    executable path.
+    Determine the path of the real python executable, which is then used for
+    venv creation. This is necessary, because an active virtualenv environment
+    will cause venv creation to malfunction. By getting the path of the real
+    executable, this issue is bypassed.
+
+    The provided `python` path may be either:
+    - A real python executable
+    - A virtualized python executable (with venv)
+    - A virtualized python executable (with virtualenv)
+
+    If the virtual environment was created with virtualenv, the `sys` module
+    will have a `real_prefix` attribute, which points to the directory where
+    the real python files are installed.
+
+    If `real_prefix` is not present, the environment was not created with
+    virtualenv, and the python executable is safe to use.
     """
     args = [str(python), '-c', 'import sys; print(sys.real_prefix)']
 

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 
 from tox.config import hookimpl
@@ -25,17 +26,24 @@ def real_python3(python):
     """
     args = [str(python), '-c', 'import sys; print(sys.real_prefix)']
 
+    # get python prefix
     process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, _ = process.communicate()
-    output = output.decode('UTF-8').strip()
-    path = os.path.join(output, 'bin/python3')
+    prefix = output.decode('UTF-8').strip()
+
+    # determine absolute binary path
+    if platform.system() == 'Windows':
+        executable = 'python.exe'
+    else:
+        executable = 'bin/python3'
+    path = os.path.join(prefix, executable)
 
     # process fails, implies *not* in active virtualenv
     if not process.returncode == 0:
         return python
 
     # the executable path must exist
-    assert os.path.isfile(path)
+    assert os.path.isfile(path), "Expected '%s' to exist." % path
     return path
 
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -13,6 +13,8 @@ from tox.venv import getdigest
 from tox.venv import tox_testenv_install_deps
 from tox.venv import VirtualEnv
 
+from tox_venv.hooks import use_builtin_venv
+
 
 def tox_testenv_create(action, venv):
     return venv.hook.tox_testenv_create(action=action, venv=venv)
@@ -59,11 +61,11 @@ def test_create(monkeypatch, mocksession, newconfig):
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
-    module = 'venv' if venv._ispython3() else 'virtualenv'
+    module = 'venv' if use_builtin_venv(venv) else 'virtualenv'
     assert module == str(args[2])
     if sys.platform != "win32":
         executable = sys.executable
-        if venv._ispython3() and hasattr(sys, 'real_prefix'):
+        if use_builtin_venv(venv) and hasattr(sys, 'real_prefix'):
             # workaround virtualenv prefixing issue w/ venv on python3
             _, executable = executable.rsplit('bin/', 1)
             executable = os.path.join(sys.real_prefix, 'bin/', executable)
@@ -489,7 +491,7 @@ class TestCreationConfig:
         assert venv.path_config.check()
         assert mocksession._pcalls
         args1 = map(str, mocksession._pcalls[0].args)
-        module = 'venv' if venv._ispython3() else 'virtualenv'
+        module = 'venv' if use_builtin_venv(venv) else 'virtualenv'
         assert module in " ".join(args1)
         mocksession.report.expect("*", "*create*")
         # modify config and check that recreation happens

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -16,6 +16,8 @@ pytest_plugins = "pytester"
 from tox.session import Session  # noqa #E402 module level import not at top of file
 from tox.config import parseconfig  # noqa #E402 module level import not at top of file
 
+from tox_venv.hooks import use_builtin_venv
+
 
 def test_report_protocol(newconfig):
     config = newconfig([], """
@@ -680,7 +682,7 @@ def test_alwayscopy(initproj, cmd, mocksession):
     assert not result.ret
 
     out = result.stdout.str()
-    if venv._ispython3():
+    if use_builtin_venv(venv):
         assert "venv --copies" in out
     else:
         assert "virtualenv --always-copy" in out
@@ -696,7 +698,7 @@ def test_alwayscopy_default(initproj, cmd, mocksession):
     assert not result.ret
 
     out = result.stdout.str()
-    if venv._ispython3():
+    if use_builtin_venv(venv):
         assert "venv --copies" not in out
     else:
         assert "virtualenv --always-copy" not in out


### PR DESCRIPTION
- Move detection into separate utility function.
- Update tests to use utility function instead of private `venv._ispython3()` method.

Fixes #1, closes #2