### PR TITLE
Update tests from tox 3.0.0

### DIFF
--- a/.travis-osx
+++ b/.travis-osx
@@ -1,6 +1,6 @@
 # Perform the manual steps on osx to install python3 and activate an environment
 brew update
-brew install python3
+brew upgrade python
 rm /usr/local/bin/python
 ln -s python3 /usr/local/bin/python
 ln -fs pip3 /usr/local/bin/pip

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,4 @@ commands = pytest {posargs:tests}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    tox
-    pytest
+    tox[testing]


### PR DESCRIPTION
Test have been updated in a two-step process. 

1. Copy tests verbatim from tox
2. Reapply test changes from tox-venv

This should make it more straightforward in the future to keep track of what changes are owned by tox, and what changes are owned by tox-venv. 