### PR TITLE
Fix macOS builds

### DIFF
--- a/.travis-osx
+++ b/.travis-osx
@@ -1,6 +1,0 @@
-# Perform the manual steps on osx to install python3 and activate an environment
-brew update
-brew upgrade python
-rm /usr/local/bin/python
-ln -s python3 /usr/local/bin/python
-ln -fs pip3 /usr/local/bin/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   include:
   - os: osx
     language: generic
+    env: TOXENV=py36
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,12 @@ matrix:
   - os: osx
     language: generic
 
-before_install: if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew upgrade python;
+      python3 -m venv venv;
+      source venv/bin/activate;
+    fi
 install:
   - pip install -U six setuptools wheel
   - pip install -U tox tox-travis


### PR DESCRIPTION
tox-travis was misconfigured, as there was no `os` mapping in the `[travis]` section of the `tox.ini`. In this case, it's simpler to fix this by just specifying the test env name with the `TOXENV` environment variable.