### PR TITLE
add compat for core refactoring

### DIFF
--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -933,11 +933,11 @@ def test_exit_code(initproj, cmd, exit_code, mocker):
     tox_ini_content = "[testenv:foo]\ncommands=python -c 'import sys; sys.exit(%d)'" % exit_code
     initproj("foo", filedefs={'tox.ini': tox_ini_content})
     cmd()
+    try:
+        from tox.exc import exit_code_str
+    except ImportError:
+        from tox import _exit_code_str as exit_code_str
     if exit_code:
-        try:
-            from tox.exc import exit_code_str
-        except ImportError:
-            from tox import _exit_code_str as exit_code_str
         # need mocker.spy above
         assert exit_code_str.call_count == 1
         (args, kwargs) = exit_code_str.call_args

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -934,7 +934,7 @@ def test_exit_code(initproj, cmd, exit_code, mocker):
     initproj("foo", filedefs={'tox.ini': tox_ini_content})
     cmd()
     try:
-        from tox.exc import exit_code_str
+        from tox.exception import exit_code_str
     except ImportError:
         from tox import _exit_code_str as exit_code_str
     if exit_code:

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -934,9 +934,13 @@ def test_exit_code(initproj, cmd, exit_code, mocker):
     initproj("foo", filedefs={'tox.ini': tox_ini_content})
     cmd()
     if exit_code:
+        try:
+            from tox.exc import exit_code_str
+        except ImportError:
+            from tox import _exit_code_str as exit_code_str
         # need mocker.spy above
-        assert tox._exit_code_str.call_count == 1
-        (args, kwargs) = tox._exit_code_str.call_args
+        assert exit_code_str.call_count == 1
+        (args, kwargs) = exit_code_str.call_args
         assert kwargs == {}
         (call_error_name, call_command, call_exit_code) = args
         assert call_error_name == 'InvocationError'
@@ -947,4 +951,4 @@ def test_exit_code(initproj, cmd, exit_code, mocker):
         assert call_exit_code == exit_code
     else:
         # need mocker.spy above
-        assert tox._exit_code_str.call_count == 0
+        assert exit_code_str.call_count == 0


### PR DESCRIPTION
Added a simple import compat layer - mainly for local development and tests - this can be removed once changes in core are merged.