### PR TITLE
Fix stderr handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -35,7 +35,7 @@ def real_python3(python, version_dict):
 
     # get python prefix
     try:
-        output = subprocess.check_output(args)
+        output = subprocess.check_output(args, stderr=subprocess.STDOUT)
         prefix = output.decode('UTF-8').strip()
     except subprocess.CalledProcessError:
         # process fails, implies *not* in active virtualenv


### PR DESCRIPTION
The stderr stream is not captured in the latest version, resulting in it being printed in tox's output. This is fixed by simply redirecting stderr to `os.devnull`.