### PR TITLE
Don't bother asserting that output is not empty. 

### DIFF
--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -490,7 +490,6 @@ def test_result_json(cmd, initproj, example123):
                 assert False, "missing {}".format(command_type)
             for command in env_data[command_type]:
                 assert isinstance(command["command"], list)
-                assert command["output"]
                 assert "retcode" in command
                 assert isinstance(command["retcode"], int)
         # virtualenv, deps install, package install, freeze


### PR DESCRIPTION
Many commands, including 'python -m venv', don't emit any output. Fixes #38.