### PR TITLE
Warn when tox-venv is used to prevent accidental use of it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ tox-venv was originally created because of compatibility issues between modern v
 unnecessary. However, there may be cases where it's preferable to create test environments directly with the
 ``venv`` module, in which case you should use tox-venv.
 
+tox-venv will emit a warning when invoked. If tox-venv is really desired, suppress the warning with the following warnings filter:
+
+    ignore:tox-venv is activated
+
 
 Installation & Usage
 --------------------

--- a/src/tox_venv/hooks.py
+++ b/src/tox_venv/hooks.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import warnings
 
 import tox
 from tox.venv import cleanup_for_venv
@@ -84,6 +85,12 @@ def tox_testenv_create(venv, action):
     # Bypass hook when venv is not available for the target python version
     if not use_builtin_venv(venv):
         return
+
+    warnings.warn(
+        "tox-venv is activated but its use is discouraged and "
+        "defects are unlikely to be fixed. "
+        "Remove the 'tox-venv' package from your environment "
+        "to use the preferred virtualenv package.")
 
     v = venv.envconfig.python_info.version_info
     version_dict = {'major': v[0], 'minor': v[1], 'micro': v[2]}

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+[pytest]
+filterwarnings=
+    ignore:tox-venv is activated
+
 [tox]
 envlist =
     py27,py35,py36,py37,py38,pypy


### PR DESCRIPTION
Allow escape hatch with warnings filter.

This change makes it clear that this project is discouraged (and helps prevent accidental use of it), but provides a means for users legitimately opting to use it to suppress the warnings. This project itself uses the escape hatch to avoid warnings about itself.